### PR TITLE
fix(build): apply kotlin-android plugin 2.4.0 explicitly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:9.2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'com.android.library'
-    id 'org.jetbrains.kotlin.android'
     id 'pl.allegro.tech.build.axion-release' version '1.21.2'
     id 'maven-publish'
     id 'jacoco'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
     id 'pl.allegro.tech.build.axion-release' version '1.21.2'
     id 'maven-publish'
     id 'jacoco'


### PR DESCRIPTION
## Summary
- AGP 9.2.1 bundles Kotlin compiler 2.2.0, but kotlin_version (and thus kotlin-reflect / transitively kotlin-stdlib) is pinned to 2.4.0
- Result: `Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.4.0, expected version is 2.2.0`, which cascades into `Unresolved reference 'listOf' / 'it' / 'minus'` errors across `ColorHash.kt`, `HSL.kt`, `RGB.kt`
- Apply the Kotlin Android plugin at the matching 2.4.0 to align compiler and runtime

Closes unhappychoice/oss-issue-opener#227

## Test plan
- [ ] GitHub Actions `build` job passes